### PR TITLE
Add README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Pure.Chart.RelationalModel.Abstractions.Serialization.System
+
+`System.Text.Json` converters for chart relational model abstractions in the **Pure** ecosystem.
+
+[![.NET build & test](https://github.com/kudima03/Pure.Chart.RelationalModel.Abstractions.Serialization.System/actions/workflows/build-and-test.yml/badge.svg?branch=main)](https://github.com/kudima03/Pure.Chart.RelationalModel.Abstractions.Serialization.System/actions/workflows/build-and-test.yml)
+[![Build and Deploy](https://github.com/kudima03/Pure.Chart.RelationalModel.Abstractions.Serialization.System/actions/workflows/publish-nuget.yml/badge.svg?branch=main)](https://github.com/kudima03/Pure.Chart.RelationalModel.Abstractions.Serialization.System/actions/workflows/publish-nuget.yml)
+[![NuGet](https://img.shields.io/nuget/v/Pure.Chart.RelationalModel.Abstractions.Serialization.System)](https://www.nuget.org/packages/Pure.Chart.RelationalModel.Abstractions.Serialization.System)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Overview
+
+`Pure.Chart.RelationalModel.Abstractions.Serialization.System` provides `System.Text.Json` converters that serialize and deserialize the chart relational model interfaces defined in [`Pure.Chart.RelationalModel.Abstractions`](https://github.com/kudima03/Pure.Chart.RelationalModel.Abstractions/tree/0.1.0-preview.6.0.0). Each interface maps to a custom `JsonConverter<T>` backed by an internal sealed record that carries `[JsonConstructor]` for round-trip fidelity.
+
+## Converters
+
+| Class | Converts |
+|---|---|
+| `ChartRelationalModelConverter` | `IChartRelationalModel` |
+| `ChartSeriesRelationalModelConverter` | `IChartSeriesRelationalModel` |
+| `AxisRelationalModelConverter` | `IAxisRelationalModel` |
+| `ChartTypeRelationalModelConverter` | `IChartTypeRelationalModel` |
+| `ChartRelationalModelAbstractionsConverters` | Enumerable collection of all four converters above |
+
+## Design Principles
+
+- **Interface-preserving** — converters target abstract interfaces, not concrete types, so any implementation serializes transparently.
+- **Internal DTOs** — each converter delegates to a private sealed record with `[JsonConstructor]`; no internal types leak into the public API.
+
+## Dependencies
+
+- [`Pure.Chart.RelationalModel.Abstractions`](https://github.com/kudima03/Pure.Chart.RelationalModel.Abstractions/tree/0.1.0-preview.6.0.0) — read-only interfaces for chart, axis, series, and chart-type relational models
+
+## Target Frameworks
+
+- .NET 7
+- .NET 8
+- .NET 9
+- .NET 10
+
+## Installation
+
+```
+dotnet add package Pure.Chart.RelationalModel.Abstractions.Serialization.System
+```
+
+## Usage
+
+```csharp
+JsonSerializerOptions options = new JsonSerializerOptions();
+
+foreach (JsonConverter converter in new ChartRelationalModelAbstractionsConverters())
+{
+    options.Converters.Add(converter);
+}
+
+string json = JsonSerializer.Serialize(chart, options);
+IChartRelationalModel deserialized = JsonSerializer.Deserialize<IChartRelationalModel>(json, options)!;
+```

--- a/src/Pure.Chart.RelationalModel.Abstractions.Serialization.System/AxisRelationalModelConverter.cs
+++ b/src/Pure.Chart.RelationalModel.Abstractions.Serialization.System/AxisRelationalModelConverter.cs
@@ -10,6 +10,7 @@ internal sealed record AxisRelationalModelJsonModel : IAxisRelationalModel
     public AxisRelationalModelJsonModel(IAxisRelationalModel model)
         : this(model.Id, model.Legend) { }
 
+    [JsonConstructor]
     public AxisRelationalModelJsonModel(IGuid id, IString legend)
     {
         Id = id;

--- a/src/Pure.Chart.RelationalModel.Abstractions.Serialization.System/ChartRelationalModelConverter.cs
+++ b/src/Pure.Chart.RelationalModel.Abstractions.Serialization.System/ChartRelationalModelConverter.cs
@@ -18,6 +18,7 @@ internal sealed record ChartRelationalModelJsonModel : IChartRelationalModel
         )
     { }
 
+    [JsonConstructor]
     public ChartRelationalModelJsonModel(
         IGuid id,
         IString title,

--- a/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/AxisRelationalModelConverterTests.cs
+++ b/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/AxisRelationalModelConverterTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Pure.Chart.RelationalModel.HashCodes;
+using Pure.Primitives.Abstractions.Serialization.System;
+using Pure.Primitives.Random.String;
+using Char = Pure.Primitives.Char.Char;
+using Guid = Pure.Primitives.Guid.Guid;
+
+namespace Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests;
+
+public sealed record AxisRelationalModelConverterTests
+{
+    private readonly JsonSerializerOptions _options;
+
+    public AxisRelationalModelConverterTests()
+    {
+        _options = new JsonSerializerOptions();
+
+        foreach (JsonConverter converter in new PrimitiveConverters())
+        {
+            _options.Converters.Add(converter);
+        }
+
+        foreach (JsonConverter converter in new ChartRelationalModelAbstractionsConverters())
+        {
+            _options.Converters.Add(converter);
+        }
+
+        _options.WriteIndented = true;
+        _options.NewLine = "\n";
+    }
+
+    [Fact]
+    public void Write()
+    {
+        Guid id = new Guid();
+        RandomString legend = new RandomString(new Char('a'), new Char('z'));
+
+        IAxisRelationalModel axis = new AxisRelationalModel(id, legend);
+
+        string serialized = JsonSerializer.Serialize(axis, _options);
+
+        Assert.Equal(
+            $$"""
+            {
+              "Id": "{{id.GuidValue}}",
+              "Legend": "{{legend.TextValue}}"
+            }
+            """,
+            serialized
+        );
+    }
+
+    [Fact]
+    public void Read()
+    {
+        Guid id = new Guid();
+        RandomString legend = new RandomString(new Char('a'), new Char('z'));
+
+        IAxisRelationalModel expected = new AxisRelationalModel(id, legend);
+
+        string input = $$"""
+            {
+              "Id": "{{id.GuidValue}}",
+              "Legend": "{{legend.TextValue}}"
+            }
+            """;
+
+        Assert.True(
+            new AxisRelationalModelHash(expected).SequenceEqual(
+                new AxisRelationalModelHash(
+                    JsonSerializer.Deserialize<IAxisRelationalModel>(input, _options)!
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void RoundTrip()
+    {
+        IAxisRelationalModel axis = new AxisRelationalModel(
+            new Guid(),
+            new RandomString(new Char('a'), new Char('z'))
+        );
+
+        IAxisRelationalModel deserialized =
+            JsonSerializer.Deserialize<IAxisRelationalModel>(
+                JsonSerializer.Serialize(axis, _options),
+                _options
+            )!;
+
+        Assert.True(
+            new AxisRelationalModelHash(axis).SequenceEqual(
+                new AxisRelationalModelHash(deserialized)
+            )
+        );
+    }
+}

--- a/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/ChartRelationalModelAbstractionsConvertersTests.cs
+++ b/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/ChartRelationalModelAbstractionsConvertersTests.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+
+namespace Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests;
+
+public sealed record ChartRelationalModelAbstractionsConvertersTests
+{
+    [Fact]
+    public void EnumeratesFourConverters()
+    {
+        Assert.Equal(4, new ChartRelationalModelAbstractionsConverters().Count());
+    }
+
+    [Fact]
+    public void NonGenericEnumeratorReturnsAllConverters()
+    {
+        IEnumerable converters = new ChartRelationalModelAbstractionsConverters();
+
+        int count = 0;
+
+        foreach (object _ in converters)
+        {
+            count++;
+        }
+
+        Assert.Equal(4, count);
+    }
+}

--- a/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/ChartRelationalModelConverterTests.cs
+++ b/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/ChartRelationalModelConverterTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Pure.Chart.RelationalModel.HashCodes;
+using Pure.Primitives.Abstractions.Serialization.System;
+using Pure.Primitives.Random.String;
+using Char = Pure.Primitives.Char.Char;
+using Guid = Pure.Primitives.Guid.Guid;
+
+namespace Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests;
+
+public sealed record ChartRelationalModelConverterTests
+{
+    private readonly JsonSerializerOptions _options;
+
+    public ChartRelationalModelConverterTests()
+    {
+        _options = new JsonSerializerOptions();
+
+        foreach (JsonConverter converter in new PrimitiveConverters())
+        {
+            _options.Converters.Add(converter);
+        }
+
+        foreach (JsonConverter converter in new ChartRelationalModelAbstractionsConverters())
+        {
+            _options.Converters.Add(converter);
+        }
+
+        _options.WriteIndented = true;
+        _options.NewLine = "\n";
+    }
+
+    [Fact]
+    public void Write()
+    {
+        Guid id = new Guid();
+        RandomString title = new RandomString(new Char('a'), new Char('z'));
+        RandomString description = new RandomString(new Char('a'), new Char('z'));
+        Guid typeId = new Guid();
+        Guid xAxisId = new Guid();
+        Guid yAxisId = new Guid();
+
+        IChartRelationalModel chart = new ChartRelationalModel(
+            id,
+            title,
+            description,
+            typeId,
+            xAxisId,
+            yAxisId
+        );
+
+        string serialized = JsonSerializer.Serialize(chart, _options);
+
+        Assert.Equal(
+            $$"""
+            {
+              "Id": "{{id.GuidValue}}",
+              "Title": "{{title.TextValue}}",
+              "Description": "{{description.TextValue}}",
+              "TypeId": "{{typeId.GuidValue}}",
+              "XAxisId": "{{xAxisId.GuidValue}}",
+              "YAxisId": "{{yAxisId.GuidValue}}"
+            }
+            """,
+            serialized
+        );
+    }
+
+    [Fact]
+    public void Read()
+    {
+        Guid id = new Guid();
+        RandomString title = new RandomString(new Char('a'), new Char('z'));
+        RandomString description = new RandomString(new Char('a'), new Char('z'));
+        Guid typeId = new Guid();
+        Guid xAxisId = new Guid();
+        Guid yAxisId = new Guid();
+
+        IChartRelationalModel expected = new ChartRelationalModel(
+            id,
+            title,
+            description,
+            typeId,
+            xAxisId,
+            yAxisId
+        );
+
+        string input = $$"""
+            {
+              "Id": "{{id.GuidValue}}",
+              "Title": "{{title.TextValue}}",
+              "Description": "{{description.TextValue}}",
+              "TypeId": "{{typeId.GuidValue}}",
+              "XAxisId": "{{xAxisId.GuidValue}}",
+              "YAxisId": "{{yAxisId.GuidValue}}"
+            }
+            """;
+
+        Assert.True(
+            new ChartRelationalModelHash(expected).SequenceEqual(
+                new ChartRelationalModelHash(
+                    JsonSerializer.Deserialize<IChartRelationalModel>(input, _options)!
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void RoundTrip()
+    {
+        IChartRelationalModel chart = new ChartRelationalModel(
+            new Guid(),
+            new RandomString(new Char('a'), new Char('z')),
+            new RandomString(new Char('a'), new Char('z')),
+            new Guid(),
+            new Guid(),
+            new Guid()
+        );
+
+        IChartRelationalModel deserialized =
+            JsonSerializer.Deserialize<IChartRelationalModel>(
+                JsonSerializer.Serialize(chart, _options),
+                _options
+            )!;
+
+        Assert.True(
+            new ChartRelationalModelHash(chart).SequenceEqual(
+                new ChartRelationalModelHash(deserialized)
+            )
+        );
+    }
+}

--- a/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/ChartSeriesRelationalModelConverterTests.cs
+++ b/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/ChartSeriesRelationalModelConverterTests.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Pure.Chart.RelationalModel.HashCodes;
+using Pure.Primitives.Abstractions.Serialization.System;
+using Pure.Primitives.Random.String;
+using Char = Pure.Primitives.Char.Char;
+using Guid = Pure.Primitives.Guid.Guid;
+
+namespace Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests;
+
+public sealed record ChartSeriesRelationalModelConverterTests
+{
+    private readonly JsonSerializerOptions _options;
+
+    public ChartSeriesRelationalModelConverterTests()
+    {
+        _options = new JsonSerializerOptions();
+
+        foreach (JsonConverter converter in new PrimitiveConverters())
+        {
+            _options.Converters.Add(converter);
+        }
+
+        foreach (JsonConverter converter in new ChartRelationalModelAbstractionsConverters())
+        {
+            _options.Converters.Add(converter);
+        }
+
+        _options.WriteIndented = true;
+        _options.NewLine = "\n";
+    }
+
+    [Fact]
+    public void Write()
+    {
+        Guid id = new Guid();
+        Guid chartId = new Guid();
+        RandomString legend = new RandomString(new Char('a'), new Char('z'));
+        RandomString xAxisSource = new RandomString(new Char('a'), new Char('z'));
+        RandomString yAxisSource = new RandomString(new Char('a'), new Char('z'));
+
+        IChartSeriesRelationalModel series = new ChartSeriesRelationalModel(
+            id,
+            chartId,
+            legend,
+            xAxisSource,
+            yAxisSource
+        );
+
+        string serialized = JsonSerializer.Serialize(series, _options);
+
+        Assert.Equal(
+            $$"""
+            {
+              "Id": "{{id.GuidValue}}",
+              "ChartId": "{{chartId.GuidValue}}",
+              "Legend": "{{legend.TextValue}}",
+              "XAxisSource": "{{xAxisSource.TextValue}}",
+              "YAxisSource": "{{yAxisSource.TextValue}}"
+            }
+            """,
+            serialized
+        );
+    }
+
+    [Fact]
+    public void Read()
+    {
+        Guid id = new Guid();
+        Guid chartId = new Guid();
+        RandomString legend = new RandomString(new Char('a'), new Char('z'));
+        RandomString xAxisSource = new RandomString(new Char('a'), new Char('z'));
+        RandomString yAxisSource = new RandomString(new Char('a'), new Char('z'));
+
+        IChartSeriesRelationalModel expected = new ChartSeriesRelationalModel(
+            id,
+            chartId,
+            legend,
+            xAxisSource,
+            yAxisSource
+        );
+
+        string input = $$"""
+            {
+              "Id": "{{id.GuidValue}}",
+              "ChartId": "{{chartId.GuidValue}}",
+              "Legend": "{{legend.TextValue}}",
+              "XAxisSource": "{{xAxisSource.TextValue}}",
+              "YAxisSource": "{{yAxisSource.TextValue}}"
+            }
+            """;
+
+        Assert.True(
+            new ChartSeriesRelationalModelHash(expected).SequenceEqual(
+                new ChartSeriesRelationalModelHash(
+                    JsonSerializer.Deserialize<IChartSeriesRelationalModel>(input, _options)!
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void RoundTrip()
+    {
+        IChartSeriesRelationalModel series = new ChartSeriesRelationalModel(
+            new Guid(),
+            new Guid(),
+            new RandomString(new Char('a'), new Char('z')),
+            new RandomString(new Char('a'), new Char('z')),
+            new RandomString(new Char('a'), new Char('z'))
+        );
+
+        IChartSeriesRelationalModel deserialized =
+            JsonSerializer.Deserialize<IChartSeriesRelationalModel>(
+                JsonSerializer.Serialize(series, _options),
+                _options
+            )!;
+
+        Assert.True(
+            new ChartSeriesRelationalModelHash(series).SequenceEqual(
+                new ChartSeriesRelationalModelHash(deserialized)
+            )
+        );
+    }
+}

--- a/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/ChartTypeRelationalModelConverterTests.cs
+++ b/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/ChartTypeRelationalModelConverterTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Pure.Chart.RelationalModel.HashCodes;
+using Pure.Primitives.Abstractions.Serialization.System;
+using Pure.Primitives.Random.String;
+using Char = Pure.Primitives.Char.Char;
+using Guid = Pure.Primitives.Guid.Guid;
+
+namespace Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests;
+
+public sealed record ChartTypeRelationalModelConverterTests
+{
+    private readonly JsonSerializerOptions _options;
+
+    public ChartTypeRelationalModelConverterTests()
+    {
+        _options = new JsonSerializerOptions();
+
+        foreach (JsonConverter converter in new PrimitiveConverters())
+        {
+            _options.Converters.Add(converter);
+        }
+
+        foreach (JsonConverter converter in new ChartRelationalModelAbstractionsConverters())
+        {
+            _options.Converters.Add(converter);
+        }
+
+        _options.WriteIndented = true;
+        _options.NewLine = "\n";
+    }
+
+    [Fact]
+    public void Write()
+    {
+        Guid id = new Guid();
+        RandomString name = new RandomString(new Char('a'), new Char('z'));
+
+        IChartTypeRelationalModel chartType = new ChartTypeRelationalModel(id, name);
+
+        string serialized = JsonSerializer.Serialize(chartType, _options);
+
+        Assert.Equal(
+            $$"""
+            {
+              "Id": "{{id.GuidValue}}",
+              "Name": "{{name.TextValue}}"
+            }
+            """,
+            serialized
+        );
+    }
+
+    [Fact]
+    public void Read()
+    {
+        Guid id = new Guid();
+        RandomString name = new RandomString(new Char('a'), new Char('z'));
+
+        IChartTypeRelationalModel expected = new ChartTypeRelationalModel(id, name);
+
+        string input = $$"""
+            {
+              "Id": "{{id.GuidValue}}",
+              "Name": "{{name.TextValue}}"
+            }
+            """;
+
+        Assert.True(
+            new ChartTypeRelationalModelHash(expected).SequenceEqual(
+                new ChartTypeRelationalModelHash(
+                    JsonSerializer.Deserialize<IChartTypeRelationalModel>(input, _options)!
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void RoundTrip()
+    {
+        IChartTypeRelationalModel chartType = new ChartTypeRelationalModel(
+            new Guid(),
+            new RandomString(new Char('a'), new Char('z'))
+        );
+
+        IChartTypeRelationalModel deserialized =
+            JsonSerializer.Deserialize<IChartTypeRelationalModel>(
+                JsonSerializer.Serialize(chartType, _options),
+                _options
+            )!;
+
+        Assert.True(
+            new ChartTypeRelationalModelHash(chartType).SequenceEqual(
+                new ChartTypeRelationalModelHash(deserialized)
+            )
+        );
+    }
+}

--- a/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/FakeTests.cs
+++ b/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/FakeTests.cs
@@ -1,7 +1,0 @@
-namespace Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests;
-
-public sealed record FakeTests
-{
-    [Fact]
-    public static void FakeTest() { }
-}

--- a/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests.csproj
+++ b/src/Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests/Pure.Chart.RelationalModel.Abstractions.Serialization.System.Tests.csproj
@@ -8,6 +8,17 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Pure.Chart.RelationalModel" Version="0.1.0-preview.3.0.0" />
+    <PackageReference
+      Include="Pure.Chart.RelationalModel.HashCodes"
+      Version="0.1.0-preview.1.0.0"
+    />
+    <PackageReference
+      Include="Pure.Primitives.Abstractions.Serialization.System"
+      Version="0.1.0-preview.0.1.1"
+    />
+    <PackageReference Include="Pure.Primitives" Version="3.6.3" />
+    <PackageReference Include="Pure.Primitives.Random" Version="0.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Adds `README.md` at the repository root
- Documents the package purpose: `System.Text.Json` converters for chart relational model abstractions
- Lists all five public types (`ChartRelationalModelAbstractionsConverters` and the four individual converters) with their target interfaces
- Explains the internal DTO / `[JsonConstructor]` pattern and the interface-preserving design principle
- Includes dependency link to `Pure.Chart.RelationalModel.Abstractions`, target frameworks, installation command, and a short usage snippet

Closes #22