### PR TITLE
Update package validation baseline to 0.1.0-preview.1.0.1

### DIFF
--- a/src/Pure.Chart.RelationalModel.Abstractions.Serialization.System/Pure.Chart.RelationalModel.Abstractions.Serialization.System.csproj
+++ b/src/Pure.Chart.RelationalModel.Abstractions.Serialization.System/Pure.Chart.RelationalModel.Abstractions.Serialization.System.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <IsAotCompatible>false</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.1.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.1.0.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Chart.RelationalModel.Abstractions.Serialization.System</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.1.0.0` to `0.1.0-preview.1.0.1` following the successful publish.