### PR TITLE
Update docs references to 0.1.0-preview.1.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ This is a **JSON serialization library** — no domain logic, just `System.Text.
 
 **Multi-targeting:** net7.0, net8.0, net9.0, net10.0. `IsAotCompatible` is `false` because the converters rely on reflection-based `System.Text.Json` behaviour.
 
-**Package validation:** `EnablePackageValidation = true` with `PackageValidationBaselineVersion = 0.1.0-preview.1.0.0`. Breaking API changes fail the build.
+**Package validation:** `EnablePackageValidation = true` with `PackageValidationBaselineVersion = 0.1.0-preview.1.0.1`. Breaking API changes fail the build.
 
 **Publishing:** triggered by pushing a semver tag (pattern `*.*.*`). The tag becomes the `PackageVersion`.
 


### PR DESCRIPTION
Update hard-coded version references in documentation from `0.1.0-preview.1.0.0` to `0.1.0-preview.1.0.1` following the release.

## Files updated
- CLAUDE.md