### PR TITLE
fix(ci): don't fail build on coverage PR comment failure

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,7 @@ jobs:
         thresholds: "${{ env.COVERAGE_THRESHOLD }} ${{ env.COVERAGE_WARNING_THRESHOLD }}"
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@v3
-      if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
+      continue-on-error: true
       with:
         recreate: true
         path: code-coverage-results.md


### PR DESCRIPTION
## Summary
- Fork PRs get a read-only `GITHUB_TOKEN`, so the "Add Coverage PR Comment"
  step always fails with `Resource not accessible by integration`, taking
  down an otherwise-passing build.
- Add `continue-on-error: true` to that step so a comment-posting failure no
  longer fails the job.
- Drop the now-unneeded `if` guard: `github.event_name == 'pull_request'` was
  already guaranteed by the workflow trigger, and the dependabot exclusion is
  no longer needed now that failures are non-fatal.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)