### PR TITLE
chore: track devcontainer updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+- package-ecosystem: "devcontainers"
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Adds a `devcontainers` ecosystem entry to `.github/dependabot.yml` so the base image and `ghcr.io/devcontainers/features/*` pins in `.devcontainer/devcontainer.json` get weekly update PRs.